### PR TITLE
implemented assassin invisibility skill (player only renders for assa…

### DIFF
--- a/networking/KillStreak/ClientGame.cpp
+++ b/networking/KillStreak/ClientGame.cpp
@@ -316,9 +316,9 @@ int ClientGame::handleCharacterSelectionPacket(ServerInputPacket* packet) {
 	// TODO: REMOVE ME*********
 	int cur_index = 0;
 	// NOTE: Change these values to select order clients choose characters
-	ArcheType player_1 = WARRIOR;
+	ArcheType player_1 = ASSASSIN;
 	ArcheType player_2 = MAGE;
-	ArcheType player_3 = ASSASSIN;
+	ArcheType player_3 = WARRIOR;
 	ArcheType diff_chars[3] = { player_1, player_2, player_3 };
 	// ************************
 

--- a/networking/KillStreak/ServerGame.cpp
+++ b/networking/KillStreak/ServerGame.cpp
@@ -11,7 +11,7 @@
 #include <process.h>					// threads
 #include <windows.h>					// sleep
 
-#define GAME_SIZE			 1			// total players required to start game
+#define GAME_SIZE			 2			// total players required to start game
 #define LOBBY_START_TIME	 500		// wait this long (ms) after all players connect
 #define START_CHAR_SELECTION 1			// start value of char selection phase
 #define END_CHAR_SELECTION   2			// end value of char selection phase

--- a/networking/KillStreak/meta_data.json
+++ b/networking/KillStreak/meta_data.json
@@ -49,10 +49,10 @@
       "skill_id": 12,
       "initial_level": 1,
       "skill_name": "INVISIBILITY",
-      "cooldown": 5.0,
+      "cooldown": 20.0,
       "range": 5.0,
       "speed": 0.0,
-      "duration": 5.0
+      "duration": 10.0
     },
     {
       "skill_id": 13,

--- a/rendering/CSE125G3/CSE125G3.vcxproj
+++ b/rendering/CSE125G3/CSE125G3.vcxproj
@@ -79,7 +79,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EBF1E546-3F93-49DB-BD9A-B629C3C6DCB0}</ProjectGuid>
     <RootNamespace>CSE125G3</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>CSE125G3</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -99,13 +99,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/rendering/ClientScene.h
+++ b/rendering/ClientScene.h
@@ -69,6 +69,7 @@ private:
 	vector<Skill> personal_skills;
 	vector<nanoseconds> skill_timers;
 	nanoseconds animation_timer;
+	nanoseconds skillDurationTimer; // used for invisibility, silence, minimap(??), 
 
 	// void removeTransform(Transform * parent, const unsigned int node_id);
 	

--- a/rendering/ServerScene.cpp
+++ b/rendering/ServerScene.cpp
@@ -381,6 +381,15 @@ void ServerScene::handlePlayerSkill(unsigned int player_id, Point finalPoint,
 		case ROYAL_CROSS:
 			handleRoyalCross(player_id, finalPoint, initPoint, adjustedSkill);
 			break;
+		case INVISIBILITY:
+		{
+			// be a little sneaky: every time i fire this, just flip the invisibility.
+			// client must send another skill packet after duration is over.
+			logger()->debug("server flipping invisibility!");
+			int node_id = scenePlayers[player_id].root_id;
+			serverSceneGraphMap[node_id]->enabled = !(serverSceneGraphMap[node_id]->enabled);
+			break;
+		}
 		default:
 		{
 			logger()->error("Skill_id {} not found!", skill_id);

--- a/rendering/Transform.cpp
+++ b/rendering/Transform.cpp
@@ -24,6 +24,11 @@ unsigned int Transform::serialize(char * data) {
 	currLoc += sizeof(unsigned int);
 	size += sizeof(unsigned int);
 
+	// copy over enabled
+	memcpy(currLoc, &enabled, sizeof(bool));
+	currLoc += sizeof(bool);
+	size += sizeof(bool);
+
 	//copying over the Transfromation Matrix
 	memcpy(currLoc, &(M[0][0]), sizeof(glm::mat4));
 	currLoc += sizeof(glm::mat4);
@@ -64,10 +69,15 @@ unsigned int Transform::deserializeAndUpdate(char * data) {
 	children_ids.clear();
 
 
-	//memCopy of node id + transform mat
+	//memCopy of node id + enabled + transform mat
 	memcpy(&node_id, currLoc, sizeof(unsigned int));
 	size += sizeof(unsigned int);
 	currLoc += sizeof(unsigned int);
+
+	memcpy(&enabled, currLoc, sizeof(bool));
+	size += sizeof(bool);
+	currLoc += sizeof(bool);
+
 	memcpy(&(M[0][0]), currLoc, sizeof(glm::mat4));
 	size += sizeof(glm::mat4);
 	currLoc += sizeof(glm::mat4);


### PR DESCRIPTION
…ssin during the duration)

utililzed the boolean value to not draw for non assassin players. The skill only flips the enabled; after the duration ends on the client side, it automatically sends another invisibility skill packet to server to reverse it. Thus, you must always make sure that the cooldown is longer than the duration.